### PR TITLE
load the token source from the Google Default Credentials

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,7 @@
 package sdhook
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -220,6 +221,22 @@ func GoogleComputeCredentials(serviceAccount string) Option {
 		return HTTPClient(&http.Client{
 			Transport: &oauth2.Transport{
 				Source: google.ComputeTokenSource(serviceAccount),
+			},
+		})(sh)
+	}
+}
+
+// GoogleDefaultCredentials is an option that loads the Google Default Credentials.
+func GoogleDefaultCredentials() Option {
+	return func(sh *StackdriverHook) error {
+		ctx := context.TODO()
+		source, err := google.DefaultTokenSource(ctx)
+		if err != nil {
+			return err
+		}
+		return HTTPClient(&http.Client{
+			Transport: &oauth2.Transport{
+				Source: source,
 			},
 		})(sh)
 	}


### PR DESCRIPTION
Here is how I got it working with modifications from the example.

``` go
    log := logrus.New()

    // create stackdriver hook
    hook, err := sdhook.New(
        // sdhook.GoogleServiceAccountCredentialsFile("./credentials.json"),
        sdhook.GoogleDefaultCredentials(),
        sdhook.ProjectID("thegoogleproject"),
        sdhook.LogName("the-log-name"),
        sdhook.Resource(sdhook.ResTypeGlobal, map[string]string{}),
    )
    if err != nil {
        log.Fatal(err)
    }

    // add to logrus
    log.Hooks.Add(hook)

    // log some message
    log.Printf("a random message @ %s", time.Now().Format("15:04:05"))
```

It may be easier to get started if the sh.service defaulted to this GoogleDefaultCredentials() and resource defaulted to the global resource type just the like `gcloud beta logging write` does in the quickstart.

https://cloud.google.com/logging/docs/quickstart-sdk
