### PR TITLE
Adding ability to send data via the logging agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ logger.Hooks.Add(h)
 logger.Printf("something %d", 15)
 ```
 
+The example above sends log entries directly to the logging API. If you have the logging agent running, you can send log entries to it instead, with the added benefit of having extra instance metadata added to your log entries by the agent. In the example above, the initialization would simply be:
+
+```go
+// create hook using the logging agent
+h, err := sdhook.New(
+	sdhook.GoogleLoggingAgent(),
+)
+```
+
 Please also see [example/example.go](example/example.go) for a more complete
 example.
 

--- a/sdhook.go
+++ b/sdhook.go
@@ -5,11 +5,14 @@ package sdhook
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/fluent/fluent-logger-golang/fluent"
 
 	logging "google.golang.org/api/logging/v2beta1"
 )
@@ -43,6 +46,10 @@ type StackdriverHook struct {
 	// partialSuccess allows partial writes of log entries if there is a badly
 	// formatted log.
 	partialSuccess bool
+
+	// agentClient defines the fluentd logger object that can send data to
+	// to the Google logging agent.
+	agentClient *fluent.Fluent
 }
 
 // New creates a StackdriverHook using the provided options that is suitible
@@ -63,13 +70,13 @@ func New(opts ...Option) (*StackdriverHook, error) {
 	}
 
 	// check service, resource, logName set
-	if sh.service == nil {
+	if sh.service == nil && sh.agentClient == nil {
 		return nil, errors.New("no stackdriver service was provided")
 	}
-	if sh.resource == nil {
+	if sh.resource == nil && sh.agentClient == nil {
 		return nil, errors.New("the monitored resource was not provided")
 	}
-	if sh.projectID == "" {
+	if sh.projectID == "" && sh.agentClient == nil {
 		return nil, errors.New("the project id was not provided")
 	}
 
@@ -120,21 +127,42 @@ func (sh *StackdriverHook) Fire(entry *logrus.Entry) error {
 		}
 
 		// write log entry
-		_, _ = sh.service.Write(&logging.WriteLogEntriesRequest{
-			LogName:        sh.logName,
-			Resource:       sh.resource,
-			Labels:         sh.labels,
-			PartialSuccess: sh.partialSuccess,
-			Entries: []*logging.LogEntry{
-				&logging.LogEntry{
-					Severity:    strings.ToUpper(entry.Level.String()),
-					Timestamp:   entry.Time.Format(time.RFC3339),
-					TextPayload: entry.Message,
-					Labels:      labels,
-					HttpRequest: httpReq,
+		if sh.agentClient != nil {
+			// The log entry payload schema is defined by the Google fluentd
+			// logging agent. See more at:
+			// https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud
+			logEntry := map[string]interface{}{
+				"severity":         strings.ToUpper(entry.Level.String()),
+				"timestampSeconds": strconv.FormatInt(entry.Time.Unix(), 10),
+				"timestampNanos":   strconv.FormatInt(entry.Time.UnixNano()-entry.Time.Unix()*1000000000, 10),
+				"message":          entry.Message,
+			}
+			for k, v := range labels {
+				logEntry[k] = v
+			}
+			if httpReq != nil {
+				logEntry["httpRequest"] = httpReq
+			}
+			if err := sh.agentClient.Post(sh.logName, logEntry); err != nil {
+				log.Printf("error posting log entries to logging agent: %s", err.Error())
+			}
+		} else {
+			_, _ = sh.service.Write(&logging.WriteLogEntriesRequest{
+				LogName:        sh.logName,
+				Resource:       sh.resource,
+				Labels:         sh.labels,
+				PartialSuccess: sh.partialSuccess,
+				Entries: []*logging.LogEntry{
+					&logging.LogEntry{
+						Severity:    strings.ToUpper(entry.Level.String()),
+						Timestamp:   entry.Time.Format(time.RFC3339),
+						TextPayload: entry.Message,
+						Labels:      labels,
+						HttpRequest: httpReq,
+					},
 				},
-			},
-		}).Do()
+			}).Do()
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
This PR adds logic to send properly structured log messages via the Google fluentd logging agent that can be installed in GCE or AWS EC2 instances and listens on port `24224` to fluentd logging requests on `localhost`. See more about the agent here:

https://cloud.google.com/error-reporting/docs/setup/compute-engine
https://cloud.google.com/error-reporting/docs/setup/ec2

Advantages of this approach instead of hitting the logging API directly:
* No need to make application code aware of the location or contents of GCP credentials or the GCP project ID. This is how I initialize the hook in my application:

```go
	gcpLoggingHook, err := sdhook.New(
		sdhook.GoogleLoggingAgent(),
	)
```

* It creates structured log entries with the logrus fields and the right log/severity levels, while also including the GCE/EC2 server metadata added by the agent.
* It's arguably a cleaner approach if you already have the agent installed in your instances shipping syslog out to Stackdriver.

This is what an entry from one of my EC2 instances looks like when viewed via the Stackdriver logging console (from an active application which is importing my fork of sdhook):

![image](https://cloud.githubusercontent.com/assets/13950/20035734/41643d20-a3ad-11e6-8e9e-bfb211b706bc.png)

You can see the red icon and the `severity` field showing that Stackdriver understands that this is an error level log message, fields from my app's logrus message inside the `structPayload` and also the ec2 metadata inside `labels`.

I'm aware that, in sending log entries via the agent, the logrus fields end up in `structPayload` instead of `labels`, but there was no way to make them show up as `labels` based on the logic in Google's fluentd agent plugin, as far as I can tell, which you can see written in Ruby here:

https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/lib/fluent/plugin/out_google_cloud.rb
