### PR TITLE
Adding ability to send messages to error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,22 @@ h, err := sdhook.New(
 Please also see [example/example.go](example/example.go) for a more complete
 example.
 
+## Error Reporting
+
+If you'd like to enable sending errors to Google's Error Reporting (https://cloud.google.com/error-reporting/), you have to set the name of the service, app or system you're running. Following the example above, the initialization would then be:
+
+```go
+// create hook using the logging agent
+h, err := sdhook.New(
+	sdhook.GoogleLoggingAgent(),
+	sdhook.ErrorReportingService("your-great-app"),
+)
+```
+
+The value of the `ErrorReportingService` function parameter above corresponds to the string value you'd like to see in the `service` field of the Error Reporting payload, as defined by https://cloud.google.com/error-reporting/docs/formatting-error-messages
+
+Also note that, if you enable error reporting, errors and messages of more severe levels go into the error log and will not be displayed in the regular log. The error log name is either defined by the `ErrorReportingLogName` function or defaults to `<regular-log-name>_errors`. This fulfills Google's Error Reporting requirement that the log name should have the string `err` in its name. See more in: https://cloud.google.com/error-reporting/docs/setup/ec2
+
+To fulfill Google's Error Reporting requirement of a payload containing error stack frame information (file name, function name and line number), it assumes that this information has been added as a `logrus.Field` of name `caller` and type `stack.Frame` from [Facebook's stack package](https://github.com/facebookgo/stack). One way to easily achieve this transparently is to use another logrus Hook like [Gurpartap](https://github.com/Gurpartap)'s [logrus-stack](https://github.com/Gurpartap/logrus-stack).
+
 See [GoDoc](https://godoc.org/github.com/knq/sdhook) for a full API listing.

--- a/sdhook.go
+++ b/sdhook.go
@@ -3,6 +3,7 @@
 package sdhook
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -12,8 +13,10 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/facebookgo/stack"
 	"github.com/fluent/fluent-logger-golang/fluent"
 
+	errorReporting "google.golang.org/api/clouderrorreporting/v1beta1"
 	logging "google.golang.org/api/logging/v2beta1"
 )
 
@@ -34,6 +37,9 @@ type StackdriverHook struct {
 	// service is the logging service.
 	service *logging.EntriesService
 
+	// service is the error reporting service.
+	errorService *errorReporting.Service
+
 	// resource is the monitored resource.
 	resource *logging.MonitoredResource
 
@@ -50,6 +56,19 @@ type StackdriverHook struct {
 	// agentClient defines the fluentd logger object that can send data to
 	// to the Google logging agent.
 	agentClient *fluent.Fluent
+
+	// errorReportingServiceName defines the value of the field <service>,
+	// required for a valid error reporting payload. If this value is set,
+	// messages where level/severity is higher than or equal to "error" will
+	// be sent to Stackdriver error reporting.
+	// See more at:
+	// https://cloud.google.com/error-reporting/docs/formatting-error-messages
+	errorReportingServiceName string
+
+	// errorReportingLogName is the name of the log for error reporting.
+	// It must contain the string "error"
+	// If not given, the string "<logName>_error" is used.
+	errorReportingLogName string
 }
 
 // New creates a StackdriverHook using the provided options that is suitible
@@ -88,7 +107,27 @@ func New(opts ...Option) (*StackdriverHook, error) {
 		}
 	}
 
+	// If error reporting log name not set, set it to log name
+	// plus string suffix
+	if sh.errorReportingLogName == "" {
+		sh.errorReportingLogName = sh.logName + "_errors"
+	}
+
 	return sh, nil
+}
+
+func isError(entry *logrus.Entry) bool {
+	if entry != nil {
+		switch entry.Level {
+		case logrus.ErrorLevel:
+			return true
+		case logrus.FatalLevel:
+			return true
+		case logrus.PanicLevel:
+			return true
+		}
+	}
+	return false
 }
 
 // Levels returns the logrus levels that this hook is applied to. This can be
@@ -128,42 +167,118 @@ func (sh *StackdriverHook) Fire(entry *logrus.Entry) error {
 
 		// write log entry
 		if sh.agentClient != nil {
-			// The log entry payload schema is defined by the Google fluentd
-			// logging agent. See more at:
-			// https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud
-			logEntry := map[string]interface{}{
-				"severity":         strings.ToUpper(entry.Level.String()),
-				"timestampSeconds": strconv.FormatInt(entry.Time.Unix(), 10),
-				"timestampNanos":   strconv.FormatInt(entry.Time.UnixNano()-entry.Time.Unix()*1000000000, 10),
-				"message":          entry.Message,
-			}
-			for k, v := range labels {
-				logEntry[k] = v
-			}
-			if httpReq != nil {
-				logEntry["httpRequest"] = httpReq
-			}
-			if err := sh.agentClient.Post(sh.logName, logEntry); err != nil {
-				log.Printf("error posting log entries to logging agent: %s", err.Error())
-			}
+			sh.sendLogMessageViaAgent(entry, labels, httpReq)
 		} else {
-			_, _ = sh.service.Write(&logging.WriteLogEntriesRequest{
-				LogName:        sh.logName,
-				Resource:       sh.resource,
-				Labels:         sh.labels,
-				PartialSuccess: sh.partialSuccess,
-				Entries: []*logging.LogEntry{
-					&logging.LogEntry{
-						Severity:    strings.ToUpper(entry.Level.String()),
-						Timestamp:   entry.Time.Format(time.RFC3339),
-						TextPayload: entry.Message,
-						Labels:      labels,
-						HttpRequest: httpReq,
-					},
-				},
-			}).Do()
+			sh.sendLogMessageViaAPI(entry, labels, httpReq)
 		}
 	}()
 
 	return nil
+}
+
+func (sh *StackdriverHook) sendLogMessageViaAgent(entry *logrus.Entry, labels map[string]string, httpReq *logging.HttpRequest) {
+	// The log entry payload schema is defined by the Google fluentd
+	// logging agent. See more at:
+	// https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud
+	logEntry := map[string]interface{}{
+		"severity":         strings.ToUpper(entry.Level.String()),
+		"timestampSeconds": strconv.FormatInt(entry.Time.Unix(), 10),
+		"timestampNanos":   strconv.FormatInt(entry.Time.UnixNano()-entry.Time.Unix()*1000000000, 10),
+		"message":          entry.Message,
+	}
+	for k, v := range labels {
+		logEntry[k] = v
+	}
+	if httpReq != nil {
+		logEntry["httpRequest"] = httpReq
+	}
+	// The error reporting payload JSON schema is defined in:
+	// https://cloud.google.com/error-reporting/docs/formatting-error-messages
+	// Which reflects the structure of the ErrorEvent type in:
+	// https://godoc.org/google.golang.org/api/clouderrorreporting/v1beta1
+	if sh.errorReportingServiceName != "" && isError(entry) {
+		errorEvent := sh.buildErrorReportingEvent(entry, labels, httpReq)
+		errorStructPayload, err := json.Marshal(errorEvent)
+		if err != nil {
+			log.Printf("error marshaling error reporting data: %s", err.Error())
+		}
+		var errorJSONPayload map[string]interface{}
+		err = json.Unmarshal(errorStructPayload, &errorJSONPayload)
+		if err != nil {
+			log.Printf("error parsing error reporting data: %s", err.Error())
+		}
+		for k, v := range logEntry {
+			errorJSONPayload[k] = v
+		}
+		if err := sh.agentClient.Post(sh.errorReportingLogName, errorJSONPayload); err != nil {
+			log.Printf("error posting error reporting entries to logging agent: %s", err.Error())
+		}
+	} else {
+		if err := sh.agentClient.Post(sh.logName, logEntry); err != nil {
+			log.Printf("error posting log entries to logging agent: %s", err.Error())
+		}
+	}
+}
+
+func (sh *StackdriverHook) sendLogMessageViaAPI(entry *logrus.Entry, labels map[string]string, httpReq *logging.HttpRequest) {
+	if sh.errorReportingServiceName != "" && isError(entry) {
+		errorEvent := sh.buildErrorReportingEvent(entry, labels, httpReq)
+		sh.errorService.Projects.Events.Report(sh.projectID, &errorEvent)
+	} else {
+		logName := sh.logName
+		if sh.errorReportingLogName != "" && isError(entry) {
+			logName = sh.errorReportingLogName
+		}
+		_, _ = sh.service.Write(&logging.WriteLogEntriesRequest{
+			LogName:        logName,
+			Resource:       sh.resource,
+			Labels:         sh.labels,
+			PartialSuccess: sh.partialSuccess,
+			Entries: []*logging.LogEntry{
+				&logging.LogEntry{
+					Severity:    strings.ToUpper(entry.Level.String()),
+					Timestamp:   entry.Time.Format(time.RFC3339),
+					TextPayload: entry.Message,
+					Labels:      labels,
+					HttpRequest: httpReq,
+				},
+			},
+		}).Do()
+	}
+}
+
+func (sh *StackdriverHook) buildErrorReportingEvent(entry *logrus.Entry, labels map[string]string, httpReq *logging.HttpRequest) errorReporting.ReportedErrorEvent {
+	errorEvent := errorReporting.ReportedErrorEvent{
+		EventTime: entry.Time.Format(time.RFC3339),
+		Message:   entry.Message,
+		ServiceContext: &errorReporting.ServiceContext{
+			Service: sh.errorReportingServiceName,
+			Version: labels["version"],
+		},
+		Context: &errorReporting.ErrorContext{
+			User: labels["user"],
+		},
+	}
+	// Assumes that caller stack frame information of type
+	// github.com/facebookgo/stack.Frame has been added.
+	// Possibly via a library like github.com/Gurpartap/logrus-stack
+	if entry.Data["caller"] != nil {
+		caller := entry.Data["caller"].(stack.Frame)
+		errorEvent.Context.ReportLocation = &errorReporting.SourceLocation{
+			FilePath:     caller.File,
+			FunctionName: caller.Name,
+			LineNumber:   int64(caller.Line),
+		}
+	}
+	if httpReq != nil {
+		errRepHttpRequest := &errorReporting.HttpRequestContext{
+			Method:    httpReq.RequestMethod,
+			Referrer:  httpReq.Referer,
+			RemoteIp:  httpReq.RemoteIp,
+			Url:       httpReq.RequestUrl,
+			UserAgent: httpReq.UserAgent,
+		}
+		errorEvent.Context.HttpRequest = errRepHttpRequest
+	}
+	return errorEvent
 }


### PR DESCRIPTION
This PR adds optional logic to send messages to Google's Error Reporting service:

https://cloud.google.com/error-reporting/

Error Reporting allows for better handling of error messages, like aggregating multiple entries of the same error as one, displaying graphs of error occurrences over time and triggering notifications.

I was able to successfully send error level (or more severe) messages to Error Reporting, using the code in this PR:

![image](https://cloud.githubusercontent.com/assets/13950/20260706/aecca06a-aa0f-11e6-9546-5feedb944d2c.png)

You'll find more details and information in the modifications I've made to the sdhook's readme.