### PR TITLE
Initialize fluentd agent with reconnect logic

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -9,7 +9,8 @@ import (
 
 func main() {
 	// create a logger with some fields
-	logger := logrus.New().WithFields(logrus.Fields{
+	logger := logrus.New()
+	logger.WithFields(logrus.Fields{
 		"my_field":  115888,
 		"my_field2": 898858,
 	})

--- a/opts.go
+++ b/opts.go
@@ -19,15 +19,6 @@ import (
 	logging "google.golang.org/api/logging/v2beta1"
 )
 
-const (
-	// DefaultAgentHost is the default host where the Google logging agent
-	// is running from.
-	DefaultAgentHost = "localhost"
-	// DefaultAgentPort is the default port that the Google logging agent
-	// is listening to.
-	DefaultAgentPort = 24224
-)
-
 // Option represents an option that modifies the Stackdriver hook settings.
 type Option func(*StackdriverHook) error
 
@@ -296,11 +287,9 @@ func GoogleLoggingAgent() Option {
 		// See more at:
 		// https://cloud.google.com/error-reporting/docs/setup/ec2
 		sh.agentClient, err = fluent.New(fluent.Config{
-			FluentHost: DefaultAgentHost,
-			FluentPort: DefaultAgentPort,
 		})
 		if err != nil {
-			return fmt.Errorf("could not find fluentd agent on %s:%d", DefaultAgentHost, DefaultAgentPort)
+			return fmt.Errorf("could not find fluentd agent on 127.0.0.1:24224")
 		}
 		return nil
 	}

--- a/opts.go
+++ b/opts.go
@@ -287,6 +287,7 @@ func GoogleLoggingAgent() Option {
 		// See more at:
 		// https://cloud.google.com/error-reporting/docs/setup/ec2
 		sh.agentClient, err = fluent.New(fluent.Config{
+			AsyncConnect: true,
 		})
 		if err != nil {
 			return fmt.Errorf("could not find fluentd agent on 127.0.0.1:24224")


### PR DESCRIPTION
Previously, if you setup the hook to connect to the fluentd agent and the agent was not available, the hook would not try to connect to the agent again.

The `AsyncConnect` option seen in:

https://github.com/fluent/fluent-logger-golang/blob/master/fluent/fluent.go#L79-L81

Asks the client to try to reconnect to the agent, up to the number of tries set by `defaultMaxRetry`, which should be good enough for most usual use cases during provisioning where one service might be starting before the other.

Now, if the agent is not available, you'll see warning messages such as the one below, until the client is able to connect to the agent:

`2016/12/02 07:14:32 error posting log entries to logging agent: fluent#send: can't send logs, client is reconnecting`

Of course, this behavior is only applicable for when you explicitly initialize the hook to use the agent using `sdhook.GoogleLoggingAgent()`

Also, did a couple o minor other commits to remove unnecessary constants and make the example compile.