### PR TITLE
opts: set MaxRetry to -1

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -288,6 +288,7 @@ func GoogleLoggingAgent() Option {
 		// https://cloud.google.com/error-reporting/docs/setup/ec2
 		sh.agentClient, err = fluent.New(fluent.Config{
 			AsyncConnect: true,
+			MaxRetry:     -1,
 		})
 		if err != nil {
 			return fmt.Errorf("could not find fluentd agent on 127.0.0.1:24224")


### PR DESCRIPTION
This prevents the fluent client from panicking.

For context, see NYTimes/video-transcoding-api#178 and
fluent/fluent-logger-golang#18.