### PR TITLE
Fix error reporting usages

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -79,7 +79,7 @@ func HTTPClient(client *http.Client) Option {
 		if err != nil {
 			return err
 		} else {
-			ErrorService(e)
+			ErrorService(e)(sh)
 		}
 
 		return LoggingService(l)(sh)

--- a/sdhook.go
+++ b/sdhook.go
@@ -223,7 +223,10 @@ func (sh *StackdriverHook) sendLogMessageViaAgent(entry *logrus.Entry, labels ma
 func (sh *StackdriverHook) sendLogMessageViaAPI(entry *logrus.Entry, labels map[string]string, httpReq *logging.HttpRequest) {
 	if sh.errorReportingServiceName != "" && isError(entry) {
 		errorEvent := sh.buildErrorReportingEvent(entry, labels, httpReq)
-		sh.errorService.Projects.Events.Report(sh.projectID, &errorEvent)
+		_, err := sh.errorService.Projects.Events.Report(sh.projectID, &errorEvent).Do()
+		if err != nil {
+			// fmt.Printf("Event Report Error: %v\n", err)
+		}
 	} else {
 		logName := sh.logName
 		if sh.errorReportingLogName != "" && isError(entry) {

--- a/sdhook.go
+++ b/sdhook.go
@@ -223,7 +223,7 @@ func (sh *StackdriverHook) sendLogMessageViaAgent(entry *logrus.Entry, labels ma
 func (sh *StackdriverHook) sendLogMessageViaAPI(entry *logrus.Entry, labels map[string]string, httpReq *logging.HttpRequest) {
 	if sh.errorReportingServiceName != "" && isError(entry) {
 		errorEvent := sh.buildErrorReportingEvent(entry, labels, httpReq)
-		_, err := sh.errorService.Projects.Events.Report(sh.projectID, &errorEvent).Do()
+		_, err := sh.errorService.Projects.Events.Report("projects/" + sh.projectID, &errorEvent).Do()
 		if err != nil {
 			// fmt.Printf("Event Report Error: %v\n", err)
 		}


### PR DESCRIPTION
- Add 2 important method calls
- Add "projects/" to `projectID` as project name
    - https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report