### PR TITLE
include nanoseconds in timestamp when reporting logs

### DIFF
--- a/sdhook.go
+++ b/sdhook.go
@@ -248,7 +248,7 @@ func (h *Hook) sendLogMessageViaAPI(entry *logrus.Entry, labels map[string]strin
 			Entries: []*logging.LogEntry{
 				{
 					Severity:    severityString(entry.Level),
-					Timestamp:   entry.Time.Format(time.RFC3339),
+					Timestamp:   entry.Time.Format(time.RFC3339Nano),
 					TextPayload: textPayload,
 					Labels:      labels,
 					HttpRequest: httpReq,


### PR DESCRIPTION
This allows logs that arrive during the same second to be ordered properly.

(LogEntry supports nanosecond resolution for timestamp, see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry )

Before:
![image](https://user-images.githubusercontent.com/6455350/139325172-b0df3ea6-dbf9-4124-8658-b080a2957949.png)
After:
![image](https://user-images.githubusercontent.com/6455350/139325193-a64bf188-01e9-47a1-bde0-7fa504072c46.png)
